### PR TITLE
Customize the contact URLs and site name used during the API key signup

### DIFF
--- a/key.md
+++ b/key.md
@@ -13,6 +13,9 @@ permalink: '/key/'
     registrationSource: 'regulations',
     apiKey: 'sxPWKJYXAGaMKMYLU0sAg0wAz4N0PkWxjNj84fAK',
     exampleApiUrl: 'https://api.data.gov/regulations/v3/documents?api_key={{api_key}}&rpp=25&po=0&dct=PR%252BFR&pd=09%257C01%257C14-09%257C30%257C14&encoded=1',
+    contactUrl: 'http://www.regulations.gov/#!contactUs',
+    siteName: 'Regulations.gov',
+    emailFromName: 'Regulations.gov',
     verifyEmail: true,
     websiteInput: true
   };


### PR DESCRIPTION
This tweaks a few config settings to better tailor the signup process to Regulations.gov (and masking api.data.gov's involvement): https://github.com/18F/api.data.gov/wiki/User-Manual:-Agencies#linking-to-your-own-contactsupport-address

This is part of an effort we're making to ensure users can more easily contact each agency's API owner, rather than funneling things through the api.data.gov contact system. since we're not experts in each agency's APIs, we don't want to be a bottleneck in providing support.

You're also welcome to tweak these config settings, these were just some suggestions since I know you already have a contact form you use.

I also took the liberty to adjust the `contact_url` and `signup_url` settings on your API Backends within the api.data.gov admin (to http://www.regulations.gov/#!contactUs and https://regulationsgov.github.io/developers/key/, respectively). We can tweak those if necessary, but that should take care of the URLs we return in API error messages. This pull request then takes care of the URLs that show up during the signup process.

Let us know if you have any questions.

cc @gbinal 
