### PR TITLE
Fix contact link in footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,6 @@ defaults:
     values:
       organization-name: "Regulations.gov"
       organization-url: "http://regulations.gov"
-      organization-email: user@agency.gov
+      organization-contact: "http://www.regulations.gov/#!contactUs"
       organization-system: "Regulations"
       site-name: /developers

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
             <a href="{{ site.github.owner_url }}">github.com/{{ site.github.owner_name }}</a>
         </li>
         <li>
-            <a href="mailto:{{ page.organization-email }}">Contact us</a>
+            <a href="{{ page.organization-contact }}">Contact us</a>
         </li>
     </ul>
 </section>


### PR DESCRIPTION
While looking into https://github.com/regulationsgov/developers/pull/56, I noticed the contact link in the footer was broken, so this should fix that.

This was previously linking to an invalid user@agency.gov e-mail link, but this changes it to link to http://www.regulations.gov/#!contactUs
