### PR TITLE
Replace http with https for api.data.gov

### DIFF
--- a/api-docs/dockets.json
+++ b/api-docs/dockets.json
@@ -1,6 +1,6 @@
 {
   "swaggerVersion": "1.2",
-  "basePath": "http://api.data.gov/regulations/v3",
+  "basePath": "https://api.data.gov/regulations/v3",
   "produces": [
     "application/json",
     "application/xml"

--- a/api-docs/documents.json
+++ b/api-docs/documents.json
@@ -1,6 +1,6 @@
 {
   "swaggerVersion": "1.2",
-  "basePath": "http://api.data.gov/regulations/v3",
+  "basePath": "https://api.data.gov/regulations/v3",
   "produces": [
     "*/*"
   ],

--- a/api-docs/regulations.json
+++ b/api-docs/regulations.json
@@ -1,6 +1,6 @@
 {
   "swaggerVersion": "1.2",
-  "basePath": "http://api.data.gov/regulations/v3",
+  "basePath": "https://api.data.gov/regulations/v3",
   "produces": [
     "application/json",
     "application/xml"

--- a/basics.md
+++ b/basics.md
@@ -19,7 +19,7 @@ A docket is an organizational folder containing multiple documents. Dockets can 
 Regulations.gov relies on api.data.gov's services for rate limiting and metrics tracking. The default rate limit of 1,000 requests per hour applies to all Regulations.gov API users. You may contact us if you require a higher request rate.
 
 #### Examples
-Return a list of all Rules and Proposed Rules posted in the month of September 2014 using this example [API Call](http://api.data.gov/regulations/v3/documents.json?rpp=25&po=0&dct=PR%252BFR&pd=09%257C01%257C14-09%257C30%257C14&encoded=1&api_key=DEMO_KEY).
+Return a list of all Rules and Proposed Rules posted in the month of September 2014 using this example [API Call](https://api.data.gov/regulations/v3/documents.json?rpp=25&po=0&dct=PR%252BFR&pd=09%257C01%257C14-09%257C30%257C14&encoded=1&api_key=DEMO_KEY).
 
 An example regulation showcasing various different fields:
 

--- a/basics2.html
+++ b/basics2.html
@@ -119,6 +119,6 @@ Regulations.gov relies on api.data.gov's services for rate limiting and metrics 
 ## Examples
 
 Return a list of all Rules and Proposed rules posted in the month of September 2014.
-http://api.data.gov/regulations/v3/documents.json?rpp=25&po=0&dct=PR%252BFR&pd=09%257C01%257C14-09%257C30%257C14&encoded=1&api_key=DEMO_KEY
+https://api.data.gov/regulations/v3/documents.json?rpp=25&po=0&dct=PR%252BFR&pd=09%257C01%257C14-09%257C30%257C14&encoded=1&api_key=DEMO_KEY
 
 <body id="basics"></body>

--- a/key.md
+++ b/key.md
@@ -27,5 +27,5 @@ permalink: '/key/'
     (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(apiUmbrella);
   })();
 </script>
-<noscript>Please enable JavaScript to signup for an <a href="http://api.data.gov/">api.data.gov</a> API key.</noscript>
+<noscript>Please enable JavaScript to signup for an <a href="https://api.data.gov/">api.data.gov</a> API key.</noscript>
 {% endraw %}


### PR DESCRIPTION
I'm hoping this is the reason that the existing API swagger pages aren't
working
